### PR TITLE
Fix CoinCbc.cpp access private variable directly

### DIFF
--- a/CoinMP/src/CoinCbc.cpp
+++ b/CoinMP/src/CoinCbc.cpp
@@ -933,7 +933,7 @@ int CbcSolveProblem(HCBC hCbc, PPROBLEM pProblem, POPTION pOption, int Method)
 #ifdef NEW_STYLE_CBCMAIN
 		if (coinGetIntOption(pOption, COIN_INT_MIPUSECBCMAIN)) {
 			CbcSolverUsefulData parameterData;
-			parameterData.noPrinting_ = true;
+			parameterData.disablePrinting();
 			CbcMain0(*pCbc->cbc, parameterData);
 			CbcSetClpOptions(hCbc, pOption);
 			CbcSetCbcOptions(hCbc, pOption);


### PR DESCRIPTION
'make' reported error:
```console
$ make
......
CoinCbc.cpp: In function 'int CbcSolveProblem(HCBC, PPROBLEM, POPTION, int)':
CoinCbc.cpp:936:39: error: 'bool CbcParameters::noPrinting_' is private within this context
  936 |                         parameterData.noPrinting_ = true;
      |                                       ^~~~~~~~~~~
/home/jenkins/Cbc/include/coin-or/CbcParameters.hpp:2054:8: note: declared private here
 2054 |   bool noPrinting_;
      |        ^~~~~~~~~~~
CoinCbc.cpp:936:39: note: field 'bool CbcParameters::noPrinting_' can be accessed via 'bool CbcParameters::noPrinting()'
  936 |                         parameterData.noPrinting_ = true;
      |                                       ^~~~~~~~~~~
      |                                       noPrinting()
```